### PR TITLE
cmd/yoke: add create namespace and crd logic to takeoff

### DIFF
--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -61,12 +61,12 @@ func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, 
 }
 
 func Descent(ctx context.Context, params DescentParams) error {
-	client, err := yoke.FromKubeConfig(params.KubeConfigPath)
+	commander, err := yoke.FromKubeConfig(params.KubeConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate k8 client: %w", err)
 	}
 
-	return client.Descent(ctx, yoke.DescentParams{
+	return commander.Descent(ctx, yoke.DescentParams{
 		Release:    params.Release,
 		RevisionID: params.RevisionID,
 	})

--- a/cmd/yoke/cmd_mayday.go
+++ b/cmd/yoke/cmd_mayday.go
@@ -46,9 +46,9 @@ func GetMaydayParams(settings GlobalSettings, args []string) (*MaydayParams, err
 }
 
 func Mayday(ctx context.Context, params MaydayParams) error {
-	client, err := yoke.FromKubeConfig(params.KubeConfigPath)
+	commander, err := yoke.FromKubeConfig(params.KubeConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to instantiate k8 client: %w", err)
 	}
-	return client.Mayday(ctx, params.Release)
+	return commander.Mayday(ctx, params.Release)
 }

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -127,7 +127,10 @@ func TakeOff(ctx context.Context, params TakeoffParams) error {
 	for _, resource := range resources {
 		mapping, err := kube.LookupResourceMapping(resource)
 		if err != nil {
-			return err
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+			return fmt.Errorf("failed to lookup resource mapping for %s: %w", internal.Canonical(resource), err)
 		}
 		if mapping.Scope.Name() == meta.RESTScopeNameNamespace && resource.GetNamespace() == "" {
 			resource.SetNamespace(cmp.Or(params.Flight.Namespace, "default"))

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -1,27 +1,18 @@
 package main
 
 import (
-	"cmp"
 	"context"
 	_ "embed"
 	"flag"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/term"
-	y3 "gopkg.in/yaml.v3"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/yaml"
 
-	"github.com/davidmdm/x/xerr"
 	"github.com/davidmdm/yoke/internal"
-	"github.com/davidmdm/yoke/internal/k8s"
-	"github.com/davidmdm/yoke/internal/text"
-	"github.com/davidmdm/yoke/internal/wasi"
+	"github.com/davidmdm/yoke/internal/home"
 	"github.com/davidmdm/yoke/pkg/yoke"
 )
 
@@ -34,17 +25,7 @@ type TakeoffFlightParams struct {
 
 type TakeoffParams struct {
 	GlobalSettings
-	TestRun          bool
-	SkipDryRun       bool
-	ForceConflicts   bool
-	Release          string
-	Out              string
-	Flight           TakeoffFlightParams
-	DiffOnly         bool
-	Context          int
-	Color            bool
-	CreateNamespaces bool
-	CreateCRDs       bool
+	yoke.TakeoffParams
 }
 
 //go:embed cmd_takeoff_help.txt
@@ -64,7 +45,9 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 
 	params := TakeoffParams{
 		GlobalSettings: settings,
-		Flight:         TakeoffFlightParams{Input: source},
+		TakeoffParams: yoke.TakeoffParams{
+			Flight: yoke.FlightParams{Input: source},
+		},
 	}
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
@@ -99,151 +82,9 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 }
 
 func TakeOff(ctx context.Context, params TakeoffParams) error {
-	defer internal.DebugTimer(ctx, "command")()
-
-	output, wasm, err := EvalFlight(ctx, params.Release, params.Flight)
-	if err != nil {
-		return fmt.Errorf("failed to evaluate flight: %w", err)
-	}
-	if params.TestRun {
-		_, err = fmt.Print(string(output))
-		return err
-	}
-
-	kube, err := k8s.NewClientFromKubeConfig(params.KubeConfigPath)
+	commander, err := yoke.FromKubeConfig(home.Kubeconfig)
 	if err != nil {
 		return err
 	}
-
-	commander := yoke.FromK8Client(kube)
-
-	var resources internal.List[*unstructured.Unstructured]
-	if err := yaml.Unmarshal(output, &resources); err != nil {
-		return fmt.Errorf("failed to unmarshal raw resources: %w", err)
-	}
-
-	complete := internal.DebugTimer(ctx, "looking up resource mappings")
-
-	for _, resource := range resources {
-		mapping, err := kube.LookupResourceMapping(resource)
-		if err != nil {
-			if meta.IsNoMatchError(err) {
-				continue
-			}
-			return fmt.Errorf("failed to lookup resource mapping for %s: %w", internal.Canonical(resource), err)
-		}
-		if mapping.Scope.Name() == meta.RESTScopeNameNamespace && resource.GetNamespace() == "" {
-			resource.SetNamespace(cmp.Or(params.Flight.Namespace, "default"))
-		}
-	}
-
-	complete()
-
-	internal.AddYokeMetadata(resources, params.Release)
-
-	if params.Out != "" {
-		if params.Out == "-" {
-			return ExportToStdout(resources)
-		}
-		return ExportToFS(params.Out, params.Release, resources)
-	}
-
-	if params.DiffOnly {
-		revisions, err := kube.GetRevisions(ctx, params.Release)
-		if err != nil {
-			return fmt.Errorf("failed to get revision history: %w", err)
-		}
-		currentResources := revisions.CurrentResources()
-
-		a, err := text.ToYamlFile("current", internal.CanonicalObjectMap(currentResources))
-		if err != nil {
-			return err
-		}
-
-		b, err := text.ToYamlFile("next", internal.CanonicalObjectMap(resources))
-		if err != nil {
-			return err
-		}
-
-		differ := func() text.DiffFunc {
-			if params.Color {
-				return text.DiffColorized
-			}
-			return text.Diff
-		}()
-
-		_, err = fmt.Fprint(internal.Stdout(ctx), differ(a, b, params.Context))
-		return err
-	}
-
-	return commander.Takeoff(ctx, yoke.TakeoffParams{
-		Release:          params.Release,
-		Resources:        resources,
-		FlightID:         params.Flight.Path,
-		Namespace:        params.Flight.Namespace,
-		Wasm:             wasm,
-		SkipDryRun:       params.SkipDryRun,
-		ForceConflicts:   params.ForceConflicts,
-		CreateCRDs:       params.CreateCRDs,
-		CreateNamespaces: params.CreateNamespaces,
-	})
-}
-
-func ExportToFS(dir, release string, resources []*unstructured.Unstructured) error {
-	root := filepath.Join(dir, release)
-
-	if err := os.RemoveAll(root); err != nil {
-		return fmt.Errorf("failed remove previous flight export: %w", err)
-	}
-
-	if err := os.MkdirAll(root, 0o755); err != nil {
-		return fmt.Errorf("failed to create release output directory: %w", err)
-	}
-
-	var errs []error
-	for _, resource := range resources {
-		path := filepath.Join(root, internal.Canonical(resource)+".yaml")
-
-		if err := internal.WriteYAML(path, resource.Object); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
-	return xerr.MultiErrFrom("failed to write resource(s)", errs...)
-}
-
-func ExportToStdout(resources []*unstructured.Unstructured) error {
-	output := make(map[string]any, len(resources))
-	for _, resource := range resources {
-		output[internal.Canonical(resource)] = resource.Object
-	}
-
-	encoder := y3.NewEncoder(os.Stdout)
-	encoder.SetIndent(2)
-	return encoder.Encode(output)
-}
-
-func EvalFlight(ctx context.Context, release string, flight TakeoffFlightParams) ([]byte, []byte, error) {
-	if flight.Input != nil && flight.Path == "" {
-		output, err := io.ReadAll(flight.Input)
-		return output, nil, err
-	}
-
-	wasm, err := yoke.LoadWasm(ctx, flight.Path)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read wasm program: %w", err)
-	}
-
-	output, err := wasi.Execute(ctx, wasi.ExecParams{
-		Wasm:    wasm,
-		Release: release,
-		Stdin:   flight.Input,
-		Args:    flight.Args,
-		Env:     map[string]string{"NAMESPACE": flight.Namespace},
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to execute wasm: %w", err)
-	}
-
-	return output, wasm, nil
+	return commander.Takeoff(ctx, params.TakeoffParams)
 }

--- a/cmd/yoke/cmd_turbulence.go
+++ b/cmd/yoke/cmd_turbulence.go
@@ -67,11 +67,11 @@ func GetTurbulenceParams(settings GlobalSettings, args []string) (*TurbulencePar
 }
 
 func Turbulence(ctx context.Context, params TurbulenceParams) error {
-	client, err := yoke.FromKubeConfig(params.KubeConfigPath)
+	commander, err := yoke.FromKubeConfig(params.KubeConfigPath)
 	if err != nil {
 		return err
 	}
-	return client.Turbulence(ctx, yoke.TurbulenceParams{
+	return commander.Turbulence(ctx, yoke.TurbulenceParams{
 		Release:       params.Release,
 		Context:       params.Context,
 		ConflictsOnly: params.ConflictsOnly,

--- a/internal/k8s/k8s.go
+++ b/internal/k8s/k8s.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"slices"
 	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -405,18 +407,10 @@ func (client Client) EnsureNamespace(ctx context.Context, namespace string) erro
 }
 
 func (client Client) GetInClusterState(ctx context.Context, resource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	mapping, err := client.LookupResourceMapping(resource)
+	resourceInterface, err := client.GetDynamicResourceInterface(resource)
 	if err != nil {
-		return nil, fmt.Errorf("failed to lookup resource mapping %w", err)
+		return nil, fmt.Errorf("failed to get dynamic resource interface: %w", err)
 	}
-
-	resourceInterface := func() dynamic.ResourceInterface {
-		resourceInterface := client.dynamic.Resource(mapping.Resource)
-		if ns := resource.GetNamespace(); ns != "" {
-			return resourceInterface.Namespace(ns)
-		}
-		return resourceInterface
-	}()
 
 	state, err := resourceInterface.Get(ctx, resource.GetName(), metav1.GetOptions{})
 	if kerrors.IsNotFound(err) {
@@ -426,7 +420,106 @@ func (client Client) GetInClusterState(ctx context.Context, resource *unstructur
 	return state, err
 }
 
+func (client Client) WaitForReady(ctx context.Context, resource *unstructured.Unstructured) error {
+	// TODO: let user configure these values?
+	var (
+		interval = 5 * time.Second
+		timeout  = 2 * time.Minute
+	)
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	done := make(chan error)
+
+	ctx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("%s timeout reached", timeout))
+	defer cancel()
+
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				done <- context.Cause(ctx)
+				return
+			case <-timer.C:
+				state, err := client.GetInClusterState(ctx, resource)
+				if err != nil {
+					done <- fmt.Errorf("failed to get in cluster state: %w", err)
+					return
+				}
+
+				if state == nil {
+					done <- fmt.Errorf("resource not found")
+					return
+				}
+
+				ready, err := isReady(state)
+				if err != nil {
+					done <- err
+					return
+				}
+
+				if ready {
+					return
+				}
+
+				timer.Reset(interval)
+			}
+		}
+	}()
+
+	return <-done
+}
+
+func (client Client) WaitForReadyMany(ctx context.Context, resources []*unstructured.Unstructured) error {
+	var wg sync.WaitGroup
+	wg.Add(len(resources))
+	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errs := make(chan error, len(resources))
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	for _, resource := range resources {
+		go func() {
+			defer wg.Done()
+			if err := client.WaitForReady(ctx, resource); err != nil {
+				errs <- fmt.Errorf("failed to get readiness for %s: %w", internal.Canonical(resource), err)
+			}
+		}()
+	}
+
+	return <-errs
+}
+
 func IsNamespaced(resource dynamic.ResourceInterface) bool {
 	_, ok := resource.(interface{ Namespace(string) bool })
 	return ok
+}
+
+func isReady(resource *unstructured.Unstructured) (bool, error) {
+	switch gk := resource.GroupVersionKind().GroupKind(); gk {
+	case schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}:
+		{
+			conditions, _, _ := unstructured.NestedSlice(resource.Object, "status", "conditions")
+			return slices.ContainsFunc(conditions, func(condition any) bool {
+				values, _ := condition.(map[string]any)
+				return values != nil && values["status"] == "True" && values["type"] == "Established"
+			}), nil
+		}
+	case schema.GroupKind{Group: "", Kind: "Namespace"}:
+		{
+			phase, _, _ := unstructured.NestedString(resource.Object, "status", "phase")
+			return phase == "Active", nil
+		}
+
+	default:
+		return false, fmt.Errorf("not implemented for GroupKind: %s", gk)
+	}
 }

--- a/internal/revision.go
+++ b/internal/revision.go
@@ -66,7 +66,7 @@ type Revision struct {
 	Resources []*unstructured.Unstructured `json:"resources"`
 }
 
-func AddHallmouiMetadata(resources []*unstructured.Unstructured, release string) {
+func AddYokeMetadata(resources []*unstructured.Unstructured, release string) {
 	for _, resource := range resources {
 		labels := resource.GetLabels()
 		if labels == nil {

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -1,0 +1,302 @@
+package yoke
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/davidmdm/x/xerr"
+	"github.com/davidmdm/yoke/internal"
+	"github.com/davidmdm/yoke/internal/k8s"
+	"github.com/davidmdm/yoke/internal/text"
+	"github.com/davidmdm/yoke/internal/wasi"
+)
+
+type FlightParams struct {
+	Path      string
+	Input     io.Reader
+	Args      []string
+	Namespace string
+}
+
+type TakeoffParams struct {
+	TestRun          bool
+	SkipDryRun       bool
+	ForceConflicts   bool
+	Release          string
+	Out              string
+	Flight           FlightParams
+	DiffOnly         bool
+	Context          int
+	Color            bool
+	CreateNamespaces bool
+	CreateCRDs       bool
+}
+
+func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) error {
+	defer internal.DebugTimer(ctx, "takeoff")()
+
+	output, wasm, err := EvalFlight(ctx, params.Release, params.Flight)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate flight: %w", err)
+	}
+	if params.TestRun {
+		_, err = fmt.Print(string(output))
+		return err
+	}
+
+	var resources internal.List[*unstructured.Unstructured]
+	if err := kyaml.Unmarshal(output, &resources); err != nil {
+		return fmt.Errorf("failed to unmarshal raw resources: %w", err)
+	}
+
+	dependencies, resources := SplitResources(resources)
+
+	if params.CreateCRDs || params.CreateNamespaces {
+		if err := commander.applyDependencies(ctx, dependencies, params); err != nil {
+			return fmt.Errorf("failed to apply flight dependencies: %w", err)
+		}
+	}
+
+	complete := internal.DebugTimer(ctx, "looking up resource mappings")
+
+	for _, resource := range resources {
+		mapping, err := commander.k8s.LookupResourceMapping(resource)
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+			return fmt.Errorf("failed to lookup resource mapping for %s: %w", internal.Canonical(resource), err)
+		}
+		if mapping.Scope.Name() == meta.RESTScopeNameNamespace && resource.GetNamespace() == "" {
+			resource.SetNamespace(cmp.Or(params.Flight.Namespace, "default"))
+		}
+	}
+
+	complete()
+
+	internal.AddYokeMetadata(resources, params.Release)
+
+	if params.Out != "" {
+		if params.Out == "-" {
+			return ExportToStdout(ctx, resources)
+		}
+		return ExportToFS(params.Out, params.Release, resources)
+	}
+
+	if params.DiffOnly {
+		revisions, err := commander.k8s.GetRevisions(ctx, params.Release)
+		if err != nil {
+			return fmt.Errorf("failed to get revision history: %w", err)
+		}
+		currentResources := revisions.CurrentResources()
+
+		a, err := text.ToYamlFile("current", internal.CanonicalObjectMap(currentResources))
+		if err != nil {
+			return err
+		}
+
+		b, err := text.ToYamlFile("next", internal.CanonicalObjectMap(resources))
+		if err != nil {
+			return err
+		}
+
+		differ := func() text.DiffFunc {
+			if params.Color {
+				return text.DiffColorized
+			}
+			return text.Diff
+		}()
+
+		_, err = fmt.Fprint(internal.Stdout(ctx), differ(a, b, params.Context))
+		return err
+	}
+
+	revisions, err := commander.k8s.GetRevisions(ctx, params.Release)
+	if err != nil {
+		return fmt.Errorf("failed to get revision history: %w", err)
+	}
+
+	previous := revisions.CurrentResources()
+
+	if reflect.DeepEqual(previous, []*unstructured.Unstructured(resources)) {
+		return internal.Warning("resources are the same as previous revision: skipping takeoff")
+	}
+
+	if err := commander.k8s.ValidateOwnership(ctx, params.Release, resources); err != nil {
+		return fmt.Errorf("failed to validate ownership: %w", err)
+	}
+
+	if targetNS := params.Flight.Namespace; targetNS != "" {
+		if err := commander.k8s.EnsureNamespace(ctx, targetNS); err != nil {
+			return fmt.Errorf("failed to ensure namespace: %w", err)
+		}
+		// TODO: wait for namespace ready
+	}
+
+	applyOpts := k8s.ApplyResourcesOpts{
+		SkipDryRun:     params.SkipDryRun,
+		ForceConflicts: params.ForceConflicts,
+	}
+
+	if err := commander.k8s.ApplyResources(ctx, resources, applyOpts); err != nil {
+		return fmt.Errorf("failed to apply resources: %w", err)
+	}
+
+	revisions.Add(resources, params.Flight.Path, wasm)
+
+	if err := commander.k8s.UpsertRevisions(ctx, params.Release, revisions); err != nil {
+		return fmt.Errorf("failed to create revision: %w", err)
+	}
+
+	removed, err := commander.k8s.RemoveOrphans(ctx, previous, resources)
+	if err != nil {
+		return fmt.Errorf("failed to remove orhpans: %w", err)
+	}
+
+	var (
+		createdNames = internal.CanonicalNameList(resources)
+		removedNames = internal.CanonicalNameList(removed)
+	)
+
+	if err := commander.k8s.UpdateResourceReleaseMapping(ctx, params.Release, createdNames, removedNames); err != nil {
+		return fmt.Errorf("failed to update resource release mapping: %w", err)
+	}
+
+	return nil
+}
+
+func (commander Commander) applyDependencies(ctx context.Context, dependencies FlightDependencies, params TakeoffParams) error {
+	defer internal.DebugTimer(ctx, "apply-dependencies")()
+
+	wg := sync.WaitGroup{}
+	errs := make([]error, 2)
+
+	applyOpts := k8s.ApplyResourcesOpts{
+		SkipDryRun:     params.SkipDryRun,
+		ForceConflicts: params.ForceConflicts,
+	}
+
+	if params.CreateCRDs {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := commander.k8s.ApplyResources(ctx, dependencies.CRDs, applyOpts); err != nil {
+				errs[0] = fmt.Errorf("failed to create CRDs: %w", err)
+				return
+			}
+			if err := commander.k8s.WaitForReadyMany(ctx, dependencies.CRDs); err != nil {
+				errs[0] = fmt.Errorf("failed to wait for CRDs to become ready: %w", err)
+				return
+			}
+		}()
+	}
+
+	if params.CreateNamespaces {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := commander.k8s.ApplyResources(ctx, dependencies.Namespaces, applyOpts); err != nil {
+				errs[1] = fmt.Errorf("failed to create namespaces: %w", err)
+				return
+			}
+			if err := commander.k8s.WaitForReadyMany(ctx, dependencies.Namespaces); err != nil {
+				errs[1] = fmt.Errorf("failed to wait for namespaces to become ready: %w", err)
+				return
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return xerr.MultiErrOrderedFrom("", errs...)
+}
+
+type FlightDependencies struct {
+	Namespaces []*unstructured.Unstructured
+	CRDs       []*unstructured.Unstructured
+}
+
+func SplitResources(resources []*unstructured.Unstructured) (deps FlightDependencies, core []*unstructured.Unstructured) {
+	for _, resource := range resources {
+		gvk := resource.GroupVersionKind()
+		switch {
+		case gvk.Kind == "Namespace" && gvk.Group == "":
+			deps.Namespaces = append(deps.Namespaces, resource)
+		case gvk.Kind == "CustomResourceDefinition" && gvk.Group == "apiextensions.k8s.io":
+			deps.CRDs = append(deps.CRDs, resource)
+		default:
+			core = append(core, resource)
+		}
+	}
+	return
+}
+
+func ExportToFS(dir, release string, resources []*unstructured.Unstructured) error {
+	root := filepath.Join(dir, release)
+
+	if err := os.RemoveAll(root); err != nil {
+		return fmt.Errorf("failed remove previous flight export: %w", err)
+	}
+
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return fmt.Errorf("failed to create release output directory: %w", err)
+	}
+
+	var errs []error
+	for _, resource := range resources {
+		path := filepath.Join(root, internal.Canonical(resource)+".yaml")
+
+		if err := internal.WriteYAML(path, resource.Object); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return xerr.MultiErrFrom("failed to write resource(s)", errs...)
+}
+
+func ExportToStdout(ctx context.Context, resources []*unstructured.Unstructured) error {
+	output := make(map[string]any, len(resources))
+	for _, resource := range resources {
+		output[internal.Canonical(resource)] = resource.Object
+	}
+
+	encoder := yaml.NewEncoder(internal.Stdout(ctx))
+	encoder.SetIndent(2)
+	return encoder.Encode(output)
+}
+
+func EvalFlight(ctx context.Context, release string, flight FlightParams) ([]byte, []byte, error) {
+	if flight.Input != nil && flight.Path == "" {
+		output, err := io.ReadAll(flight.Input)
+		return output, nil, err
+	}
+
+	wasm, err := LoadWasm(ctx, flight.Path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read wasm program: %w", err)
+	}
+
+	output, err := wasi.Execute(ctx, wasi.ExecParams{
+		Wasm:    wasm,
+		Release: release,
+		Stdin:   flight.Input,
+		Args:    flight.Args,
+		Env:     map[string]string{"NAMESPACE": flight.Namespace},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to execute wasm: %w", err)
+	}
+
+	return output, wasm, nil
+}


### PR DESCRIPTION
This PR is the implementation outlined in issue #19. It also includes some cleanup around certain naming conventions internally in the code.

TODO:
- [x] add --create-namespaces and --create-crds flags
- [x] add crd and namespace creation logic
- [x] add wait mechanism for namespaces and crds
- [x] test create-namespaces
- [x] test create-crds
- [x] review