### PR TITLE
Support takeoff/descent wait via  workload readiness

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,7 +13,7 @@ tasks:
 
   test:
     cmds:
-      - kind delete cluster && kind create cluster
+      - kind delete cluster --name=tests && kind create cluster --name=tests
       - go test -coverprofile cover.out -p 1 -v ./...
 
   wasm:

--- a/cmd/yoke/cmd_descent.go
+++ b/cmd/yoke/cmd_descent.go
@@ -21,8 +21,7 @@ func init() {
 
 type DescentParams struct {
 	GlobalSettings
-	Release    string
-	RevisionID int
+	yoke.DescentParams
 }
 
 func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, error) {
@@ -38,6 +37,8 @@ func GetDescentfParams(settings GlobalSettings, args []string) (*DescentParams, 
 	}
 
 	RegisterGlobalFlags(flagset, &params.GlobalSettings)
+
+	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to become ready")
 
 	flagset.Parse(args)
 
@@ -65,9 +66,5 @@ func Descent(ctx context.Context, params DescentParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to instantiate k8 client: %w", err)
 	}
-
-	return commander.Descent(ctx, yoke.DescentParams{
-		Release:    params.Release,
-		RevisionID: params.RevisionID,
-	})
+	return commander.Descent(ctx, params.DescentParams)
 }

--- a/cmd/yoke/cmd_takeoff.go
+++ b/cmd/yoke/cmd_takeoff.go
@@ -63,6 +63,7 @@ func GetTakeoffParams(settings GlobalSettings, source io.Reader, args []string) 
 	flagset.IntVar(&params.Context, "context", 4, "number of lines of context in diff (ignored if not using --diff-only)")
 	flagset.StringVar(&params.Out, "out", "", "if present outputs flight resources to directory specified, if out is - outputs to standard out")
 	flagset.StringVar(&params.Flight.Namespace, "namespace", "default", "preferred namespace for resources if they do not define one")
+	flagset.DurationVar(&params.Wait, "wait", 0, "time to wait for release to be ready")
 
 	args, params.Flight.Args = internal.CutArgs(args)
 

--- a/internal/k8s/readiness.go
+++ b/internal/k8s/readiness.go
@@ -1,0 +1,91 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// isReady checks for readiness of workload resources, namespaces, and CRDs
+func isReady(_ context.Context, resource *unstructured.Unstructured) bool {
+	gvk := resource.GroupVersionKind()
+
+	switch gvk.Group {
+	case "":
+		switch gvk.Kind {
+		case "Namespace":
+			phase, _, _ := unstructured.NestedString(resource.Object, "status", "phase")
+			return phase == "Active"
+		case "Pod":
+			return meetsConditions(resource, "Available")
+		}
+	case "apps":
+		switch gvk.Kind {
+		case "Deployment":
+			return true &&
+				meetsConditions(resource, "Available") &&
+				equalInts(resource, "replicas", "availableReplicas", "readyReplicas", "updatedReplicas")
+		case "ReplicaSet", "StatefulSet":
+			return equalInts(resource, "replicas", "availableReplicas", "readyReplicas", "updatedReplicas")
+		case "DaemonSet":
+			return equalInts(
+				resource,
+				"currentNumberScheduled",
+				"desiredNumberScheduled",
+				"updatedNumberScheduled",
+				"numberAvailable",
+				"numberReady",
+			)
+		}
+	case "apiextensions.k8s.io":
+		switch gvk.Kind {
+		case "CustomResourceDefinition":
+			return meetsConditions(resource, "Established")
+		}
+	}
+
+	return true
+}
+
+func meetsConditions(resource *unstructured.Unstructured, keys ...string) bool {
+	conditions, _, _ := unstructured.NestedSlice(resource.Object, "status", "conditions")
+
+	trueConditions := map[string]bool{}
+	for _, condition := range conditions {
+		values, _ := condition.(map[string]any)
+		cond, _ := values["type"].(string)
+		if cond == "" {
+			continue
+		}
+		trueConditions[cond] = values["status"] == "True"
+	}
+
+	for _, key := range keys {
+		if !trueConditions[key] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func equalInts(resource *unstructured.Unstructured, keys ...string) bool {
+	if len(keys) == 0 {
+		return true
+	}
+
+	values := []int64{}
+	for _, key := range keys {
+		value, _, _ := unstructured.NestedInt64(resource.Object, "status", key)
+		values = append(values, value)
+	}
+
+	wanted := values[0]
+	for _, value := range values[1:] {
+		if value != wanted {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/yoke/yoke_takeoff.go
+++ b/pkg/yoke/yoke_takeoff.go
@@ -178,7 +178,7 @@ func (commander Commander) Takeoff(ctx context.Context, params TakeoffParams) er
 
 	if params.Wait > 0 {
 		if err := commander.k8s.WaitForReadyMany(ctx, resources, k8s.WaitOptions{Timeout: params.Wait}); err != nil {
-			return fmt.Errorf("release did not become ready within %s timeout: to rollback use `yoke descent`: %w", params.Wait.String(), err)
+			return fmt.Errorf("release did not become ready within wait period: to rollback use `yoke descent`: %w", err)
 		}
 	}
 


### PR DESCRIPTION
The goal of this PR is to add the ability to "--wait" for a packages workload resources to be ready before returning.

Closes issue #9 

TODO:
- [X] Add basic readiness checks for workload resources (pods, deployments, replicasets, and so on...)
- [x] Add `--wait` flag for Takeoff/Descent/Turbulence? commands
- [x] Tests
 
