### PR TITLE
yoke: breaking change: represent revision history as multiple secrets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,12 @@ go install github.com/davidmdm/yoke/cmd/yoke@latest
 
 Official documentation can be found [here](https://davidmdm.github.io/yoke-website)
 
+## Versioning
+
+This project is still pre version 1.0.0
+
+The project uses semantic versioning but due to is pre 1.0.0 state, breaking changes are represented as minor bumps and all other changes patches until the release of yoke v1.0.0
+
 ## Contributions
 
 Contributions are welcome! If you encounter any issues or have suggestions, please open an issue on the yoke GitHub repository.


### PR DESCRIPTION
This PR changes way that yoke represents revisions internally.

Previously, for convenience, a release's revision state would be stored in a single kubernetes secret, and its value upserted as revisions were created. However this limited any given release to have a maximum combined history of 1mb. This meant that for large installations, you couldn't have many revisions before hitting the memory limit.

This PR changes the behaviour such that every revision is its own secret, meaning that the revision history is now unbounded other than a single revision entry must be under 1mb.